### PR TITLE
Adding route53 support for Jenkins-Slave

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -21,7 +21,7 @@ mod 'puppetlabs/concat', '3.0.0' # postgresql requires concat < 3.0.0
 mod 'puppetlabs/stdlib', :latest
 mod 'puppetlabs/vcsrepo', :latest
 mod 'puppetlabs/firewall', :latest
-# mod 'puppetlabs/aws', :latest
+mod 'puppetlabs-aws', :latest
 mod 'jdowning/rbenv', :latest
 mod 'trlinkin/noop', :latest
 mod 'puppetlabs/catalog_preview', :latest

--- a/hieradata/role/jenkins-slave.yaml
+++ b/hieradata/role/jenkins-slave.yaml
@@ -3,6 +3,7 @@ psick::pre::windows_classes:
   chocolatey: chocolatey
 psick::base::windows_classes:
   jenkins_slave: profile::ssh_windows
+  dns: profile::route53
   packages: psick::packages
   openssh: psick::openssh
 psick::profiles::windows_classes:
@@ -10,6 +11,10 @@ psick::profiles::windows_classes:
   services: psick::windows::services
   puppet: psick::puppet::pe_agent
   reboot: psick::reboot
+profile::route53::environment: "%{::env}"
+profile::route53::zone: 'graduway.com'
+profile::route53::hostname: "%{::role}"
+profile::route53::ip_address: "%{::ipaddress}"
 
 # Do not try to install openssh on Windows via tp
 psick::openssh::use_tp: false

--- a/site/profile/manifests/route53.pp
+++ b/site/profile/manifests/route53.pp
@@ -1,0 +1,14 @@
+class profile::route53 (
+	String $domain		='graduway.com.',
+	String $environment	= undef,
+	String $hostname	= undef,
+	String $ip_address	= undef,
+){
+
+  route53_a_record { "${hostname}.${environment}.${domain}":
+    ensure => present,
+    zone   => "${environment}.${domain}",
+    ttl    => 300,
+    values => ["${ip_address}"],
+  }
+}


### PR DESCRIPTION
Adding Route53 registration for Jenkins-Slave

- Using puppet-aws module

- Using IP address from facter