### PR TITLE
Adding vpc-network and subdomain variables to openvpn

### DIFF
--- a/hieradata/role/openvpn.yaml
+++ b/hieradata/role/openvpn.yaml
@@ -36,15 +36,17 @@ openvpn::servers:
     organization: 'Graduway'
     email: 'development@graduway.com'
     server: '192.168.200.0 255.255.255.0'
-    push: ["route 172.16.0.0 255.255.0.0"]
+    push: ["route %{::vpc_subnet}"]
+
 
 openvpn::server_defaults:
  logfile: "/var/log/openvpn.log"
 
 openvpn::client_defaults:
   server: 'graduway-vpn'
-  remote_host: "vpn.%{::env}.graduway.com"
+  remote_host: "vpn.%{::region_env}.graduway.com"
   mail_from: "devops@graduway.com"
+  mail_domain: "graduway.com"
 openvpn::clients:
   'yacov.barboi': {}
   'antony.gelberg': {}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -24,6 +24,12 @@ if $ec2_tag_env {
 if $ec2_tag_name {
   $host_name = $ec2_tag_name
 }
+if $ec2_tag_region_env {
+  $region_env = $ec2_tag_region_env
+}
+if $ec2_tag_network {
+  $vpc_subnet = $ec2_tag_network
+}
 if defined('$facts') and defined('$trusted') {
   if $trusted['extensions']['pp_role'] and !has_key($facts,'role') {
     $role = $trusted['extensions']['pp_role']


### PR DESCRIPTION
Closes #60 #84 
vpc-network variables are translated into openvpn configuration
Uses subdomain in openvpn hostname
