### PR TITLE
Replacing variable names to env_region

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -167,5 +167,5 @@ psick::puppet::tp::resources_hash:
     puppet-agent:
       template: profile/puppet.conf.erb 
 psick::puppet::tp::options_hash:
-  server: "puppet.%{::region_env}.graduway.com"
+  server: "puppet.%{::env_region}.graduway.com"
   noop: false

--- a/hieradata/role/openvpn.yaml
+++ b/hieradata/role/openvpn.yaml
@@ -43,10 +43,10 @@ openvpn::server_defaults:
 
 openvpn::client_defaults:
   server: 'graduway-vpn'
-  remote_host: "vpn.%{::region_env}.graduway.com"
+  remote_host: "vpn.%{::env_region}.graduway.com"
   mail_from: "devops@graduway.com"
   mail_domain: "graduway.com"
-  environment: "%{::region_env}"
+  environment: "%{::env_region}"
 openvpn::clients:
   'yacov.barboi': {}
   'antony.gelberg': {}

--- a/hieradata/role/puppet_foss_master.yaml
+++ b/hieradata/role/puppet_foss_master.yaml
@@ -5,5 +5,5 @@ psick::profiles::linux_classes:
 
 psick::puppet::gems::install_puppetserver_gems: true
 psick::puppet::autosign::autosign: 'on'
-psick::puppet::autosign::autosign_match: "*.%{::region_env}.graduway.com"
+psick::puppet::autosign::autosign_match: "*.%{::env_region}.graduway.com"
 

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -29,8 +29,8 @@ if $ec2_tag_env {
 if $ec2_tag_name {
   $host_name = $ec2_tag_name
 }
-if $ec2_tag_region_env {
-  $region_env = $ec2_tag_region_env
+if $ec2_tag_env_region {
+  $env_region = $ec2_tag_env_region
 }
 if $ec2_tag_network {
   $vpc_subnet = $ec2_tag_network


### PR DESCRIPTION
Replacing env_region on ec2tags affect psick variables
