### PR TITLE
Pin puppetlabs/apt module to 6.2.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -46,7 +46,7 @@ mod 'puppet/puppetserver', :latest
 mod 'puppetlabs/puppetserver_gem', :latest
 mod 'puppet/r10k', :latest
 mod 'puppetlabs/hocon', :latest
-mod 'puppetlabs/apt', :latest
+mod 'puppetlabs/apt', '6.2.1'
 mod 'puppet/puppetboard', :latest
 
 # Used by psick::puppet::pe_code_manager


### PR DESCRIPTION
This commit changes puppetlabs/apt from latest to 6.2.1.
We need it becuase due to new 6.3.0 version we have deps loop.
See #105 for details